### PR TITLE
Updated header-content to make it same with landing

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -1,17 +1,19 @@
 <header class="header">
   <nav class="navbar">
     <div class="navbar-brand">
+      <img
+        class="logo"
+        alt="Hazelcast"
+        srcset="{{{uiRootPath}}}/img/hazelcast-logo-white.png 1x, {{{uiRootPath}}}/img/hazelcast-logo-white@2x.png 2x, {{{uiRootPath}}}/img/hazelcast-logo-white@3x.png 3x"
+      />
       {{#with site.homeUrl}}
-        <a class="navbar-item" href="{{{relativize this}}}">{{site.title}}</a>
+      <a class="navbar-item" href="{{{relativize this}}}">Hazelcast Guides</a>
       {{/with}}
       <button class="navbar-burger" data-target="topbar-nav">
         <span></span>
         <span></span>
         <span></span>
       </button>
-      {{#with site.homeUrl}}
-      <a href="{{{relativize this}}}" class="navbar-home-button"></a>
-      {{/with}}
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">


### PR DESCRIPTION
Currently, the landing page header is displayed like this:
![image](https://user-images.githubusercontent.com/7557235/115006799-2f92b880-9ea1-11eb-9e0c-e4d3a9423786.png)
and the header of the actual guide pages are displayed like this:
![image](https://user-images.githubusercontent.com/7557235/115006683-1558da80-9ea1-11eb-8b9f-b1a6db53ccdf.png)

The content headers don't have the Hazelcast logo and `Hazelcast Guides` main title. This PR makes all the headers the same, and after merging the content headers will be displayed like this:
![image](https://user-images.githubusercontent.com/7557235/115007257-b21b7800-9ea1-11eb-9663-7b4ba610bed1.png)

The `Hazelcast Guides` title has the link to the landing page, but we will lose the home icon. However, IMO it is still better and looks more professional.